### PR TITLE
Add `getTrimEdges()` function and typedocs

### DIFF
--- a/.changeset/fast-beds-dance.md
+++ b/.changeset/fast-beds-dance.md
@@ -1,0 +1,5 @@
+---
+'trim-image-data': patch
+---
+
+Add typedocs to exported types and functions.

--- a/.changeset/thirty-trains-burn.md
+++ b/.changeset/thirty-trains-burn.md
@@ -1,0 +1,6 @@
+---
+'trim-image-data': minor
+---
+
+Add `getTrimEdges()` function, which returns the calculated edges of the trim without cropping the
+image.

--- a/README.md
+++ b/README.md
@@ -59,9 +59,33 @@ not mutate the recieved instance.
 
 **Parameters:**
 
-- `imageData` - the ImageData-instance instance to crop
+- `imageData` - the ImageData-instance to crop
 
-- `cropOptions` - optional, an object specifying the amount of pixels to crop from each side
+- `trimOptions` - optional
+
+  - `trimColor([red, green, blue, alpha]) => boolean` | `trimColor: [r, g, b, a]`  
+    Callback function used to determine if a value should be trimmed or not. Receives an object of
+    RGBA channels and should return a boolean.
+
+    Also accepts a single RGBA-array as a shorthand for a callback that returns `true` if all
+    channels are equal to the corresponding channel in the array.
+
+**Return value:**
+
+A new, trimmed ImageData-instance.
+
+### `getTrimEdges(imageData, trimOptions)`
+
+Calculates the number of pixels to trim from each side of an image, provided as an ImageData object.
+Does not actually trim the image.
+
+Uses the same options and defaults as `trimImageData`.
+
+**Parameters:**
+
+- `imageData` - the ImageData-instance to calculate the trim for
+
+- `trimOptions` - optional
 
   - `trimColor([red, green, blue, alpha]) => boolean` | `trimColor: [r, g, b, a]`  
     Callback function used to determine if a value should be trimmed or not. Receives an object of

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,16 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "linter": {
-    "enabled": true
+    "enabled": true,
+    "rules": {
+      "suspicious": {
+        "noExplicitAny": "off"
+      },
+      "style": {
+        "useTemplate": "off",
+        "noUnusedTemplateLiteral": "off"
+      }
+    }
   },
   "organizeImports": {
     "enabled": false

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,10 +1,20 @@
-import ImageData from '@canvas/image-data';
+import IsomorphicImageData from '@canvas/image-data';
 import { describe, expect, it } from 'vitest';
-import trimImageData, { RGBA } from './index.js';
 import { getTestImageData } from '../test/testImageData.js';
+import trimImageData, { RGBA, TrimEdges, getTrimEdges } from './index.js';
 
-// biome-ignore lint/suspicious/noExplicitAny: test override
-(global as any).ImageData = ImageData;
+global.ImageData = IsomorphicImageData as any;
+
+type ImageDataCellLike = [number, number, number, number];
+
+/** Transparent ImageData cell*/
+const t: ImageDataCellLike = [0, 0, 0, 0];
+
+/** White ImageData cell */
+const w: ImageDataCellLike = [0, 0, 0, 255];
+
+/** Black ImageData cell */
+const b: ImageDataCellLike = [255, 255, 255, 255];
 
 function isSameData(dataA: Uint8ClampedArray | number[], dataB: Uint8ClampedArray | number[]) {
   if (dataA.length !== dataB.length) {
@@ -14,103 +24,131 @@ function isSameData(dataA: Uint8ClampedArray | number[], dataB: Uint8ClampedArra
   return dataA.join() === dataB.join();
 }
 
-describe('test data arrays', () => {
-  const t = [0, 0, 0, 0]; // transparent
-  const w = [0, 0, 0, 255]; // white
-  const b = [255, 255, 255, 255]; // black
+function flat(arr: number[][]) {
+  return arr.reduce((acc, val) => acc.concat(val), []);
+}
 
-  function flat(arr: number[][]) {
-    return arr.reduce((acc, val) => acc.concat(val), []);
-  }
-
-  it('trims transparent pixels by default', () => {
+describe(getTrimEdges.name, () => {
+  it('returns expected trim edges', () => {
     // prettier-ignore
     const dataIn = flat([
       t, t, t, t, t, t,
-      t, t, b, b, t, t,
+      t, t, t, t, t, t,
       t, b, b, b, b, t,
       t, b, b, b, b, t,
-      t, t, b, b, t, t,
+      t, t, t, t, t, t,
       t, t, t, t, t, t,
     ]);
 
-    // prettier-ignore
-    const expectedDataOut = flat([
-      t, b, b, t,
-      b, b, b, b,
-      b, b, b, b,
-      t, b, b, t,
-    ]);
-
-    const imageData = new ImageData(Uint8ClampedArray.from(dataIn), 6, 6);
-    const result = trimImageData(imageData);
-
-    expect(result.width).toEqual(4);
-    expect(result.height).toEqual(4);
-    expect(isSameData(result.data, expectedDataOut)).toBe(true);
+    const result = getTrimEdges(new ImageData(Uint8ClampedArray.from(dataIn), 6, 6));
+    expect(result).toEqual({ top: 2, bottom: 2, left: 1, right: 1 });
   });
 
-  it.each([
-    {
-      label: 'callback',
-      trimColor: ([red, green, blue, alpha]: RGBA) =>
-        red === 255 && green === 255 && blue === 255 && alpha === 255,
-    },
-    { label: 'shorthand', trimColor: [255, 255, 255, 255] as [number, number, number, number] },
-  ])('trims custom pixels through trimColor function ($label)', ({ trimColor }) => {
+  it('returns null if the whole image should be trimmed', () => {
     // prettier-ignore
     const dataIn = flat([
-      b, b, b, b, b, b,
-      b, b, w, w, b, b,
-      b, w, w, w, w, b,
-      b, w, w, w, w, b,
-      b, b, w, w, b, b,
-      b, b, b, b, b, b,
+      t, t, t, t,
+      t, t, t, t,
+      t, t, t, t,
+      t, t, t, t,
     ]);
 
-    // prettier-ignore
-    const expectedDataOut = flat([
-      b, w, w, b,
-      w, w, w, w,
-      w, w, w, w,
-      b, w, w, b,
-    ]);
-
-    const imageData = new ImageData(Uint8ClampedArray.from(dataIn), 6, 6);
-    const result = trimImageData(imageData, { trimColor });
-
-    expect(result.width).toEqual(4);
-    expect(result.height).toEqual(4);
-    expect(isSameData(result.data, expectedDataOut)).toBe(true);
-  });
-
-  it('does nothing if ImageData is already trimmed', () => {
-    // prettier-ignore
-    const dataIn = flat([
-      t, b, b, t,
-      b, b, b, b,
-      b, b, b, b,
-      t, b, b, t,
-    ]);
-
-    const imageData = new ImageData(Uint8ClampedArray.from(dataIn), 4, 4);
-    const result = trimImageData(imageData);
-    expect(isSameData(result.data, dataIn)).toBe(true);
+    const result = getTrimEdges(new ImageData(Uint8ClampedArray.from(dataIn), 4, 4));
+    expect(result).toEqual(null);
   });
 });
 
-describe('test real images', () => {
-  const images = ['mario', 'sans'];
-
-  it.each(images)('correctly trims image: %p', async key => {
-    const [untrimmedImageData, trimmedImageData] = await Promise.all([
-      getTestImageData(`${key}.png`),
-      getTestImageData(`${key}_trimmed.png`),
+describe(trimImageData.name, () => {
+  describe('test data arrays', () => {
+    it('trims transparent pixels by default', () => {
+      // prettier-ignore
+      const dataIn = flat([
+      t, t, t, t, t, t,
+      t, t, b, b, t, t,
+      t, b, b, b, b, t,
+      t, b, b, b, b, t,
+      t, t, b, b, t, t,
+      t, t, t, t, t, t,
     ]);
 
-    const result = trimImageData(untrimmedImageData);
-    expect(result.width).toEqual(trimmedImageData.width);
-    expect(result.height).toEqual(trimmedImageData.height);
-    expect(isSameData(result.data, trimmedImageData.data)).toBe(true);
+      // prettier-ignore
+      const expectedDataOut = flat([
+      t, b, b, t,
+      b, b, b, b,
+      b, b, b, b,
+      t, b, b, t,
+    ]);
+
+      const imageData = new ImageData(Uint8ClampedArray.from(dataIn), 6, 6);
+      const result = trimImageData(imageData);
+
+      expect(result.width).toEqual(4);
+      expect(result.height).toEqual(4);
+      expect(isSameData(result.data, expectedDataOut)).toBe(true);
+    });
+
+    it.each([
+      {
+        label: 'callback',
+        trimColor: ([red, green, blue, alpha]: RGBA) =>
+          red === 255 && green === 255 && blue === 255 && alpha === 255,
+      },
+      { label: 'shorthand', trimColor: [255, 255, 255, 255] as [number, number, number, number] },
+    ])('trims custom pixels through trimColor function ($label)', ({ trimColor }) => {
+      // prettier-ignore
+      const dataIn = flat([
+        b, b, b, b, b, b,
+        b, b, w, w, b, b,
+        b, w, w, w, w, b,
+        b, w, w, w, w, b,
+        b, b, w, w, b, b,
+        b, b, b, b, b, b,
+      ]);
+
+      // prettier-ignore
+      const expectedDataOut = flat([
+        b, w, w, b,
+        w, w, w, w,
+        w, w, w, w,
+        b, w, w, b,
+      ]);
+
+      const imageData = new ImageData(Uint8ClampedArray.from(dataIn), 6, 6);
+      const result = trimImageData(imageData, { trimColor });
+
+      expect(result.width).toEqual(4);
+      expect(result.height).toEqual(4);
+      expect(isSameData(result.data, expectedDataOut)).toBe(true);
+    });
+
+    it('does nothing if ImageData is already trimmed', () => {
+      // prettier-ignore
+      const dataIn = flat([
+      t, b, b, t,
+      b, b, b, b,
+      b, b, b, b,
+      t, b, b, t,
+    ]);
+
+      const imageData = new ImageData(Uint8ClampedArray.from(dataIn), 4, 4);
+      const result = trimImageData(imageData);
+      expect(isSameData(result.data, dataIn)).toBe(true);
+    });
+  });
+
+  describe('test real images', () => {
+    const images = ['mario', 'sans'];
+
+    it.each(images)('correctly trims image: %p', async key => {
+      const [untrimmedImageData, trimmedImageData] = await Promise.all([
+        getTestImageData(`${key}.png`),
+        getTestImageData(`${key}_trimmed.png`),
+      ]);
+
+      const result = trimImageData(untrimmedImageData);
+      expect(result.width).toEqual(trimmedImageData.width);
+      expect(result.height).toEqual(trimmedImageData.height);
+      expect(isSameData(result.data, trimmedImageData.data)).toBe(true);
+    });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,35 @@
 import cropImageData, { CropOptions, ImageDataLike } from 'crop-image-data';
 
 type ImageDataLikeData = Uint8ClampedArray | number[];
-
-export type RGBA = [number, number, number, number];
-
-export type TrimColorFunc = (rgba: RGBA) => boolean;
-
 type Side = 'top' | 'right' | 'bottom' | 'left';
 
+/**
+ * RGBA color representation as an array of 4 numbers: red, green, blue, alpha.
+ */
+export type RGBA = [number, number, number, number];
+
+/**
+ * Function that returns `true` if the pixel should be trimmed, `false` otherwise.
+ *
+ * @example
+ * const trimOpaque: TrimColorFunc = ([r, g, b, a]) => a === 255;
+ * const trimWhite: TrimColorFunc = ([r, g, b, a]) => r === 255 && g === 255 && b === 255;
+ * const trimAnyRedChannel: TrimColorFunc = ([r, g, b, a]) => r > 0;
+ */
+export type TrimColorFunc = (rgba: RGBA) => boolean;
+
+/**
+ * Object representing the number of pixels to trim from each side of an image.
+ */
 export type TrimEdges = Required<CropOptions>;
 
+/**
+ * Options to configure the trim operation.
+ */
 export interface TrimOptions {
+  /**
+   * Color to trim from the edges of the image. Can be specified as an RGBA array or a function that returns `true` if the pixel should be trimmed.
+   */
   trimColor: TrimColorFunc | RGBA;
 }
 
@@ -63,6 +82,14 @@ function scanSide(imageData: ImageDataLike, side: Side, trimColor: TrimColorFunc
   return null;
 }
 
+/**
+ * Calculates the number of pixels to trim from each side of an image, provided as an ImageData object.
+ * Does not actually trim the image.
+ *
+ * @param imageData `ImageData` of the image to calculate the trim for
+ * @param trimOptions Options to configure the trim operation
+ * @returns the number of pixels to trim from each side of the image
+ */
 export function getTrimEdges(
   imageData: ImageDataLike,
   trimOptions?: TrimOptions
@@ -86,6 +113,14 @@ export function getTrimEdges(
   return trimEdges as TrimEdges;
 }
 
+/**
+ * Trims pixels from the edges of an image, provided as an ImageData object. Trims transparent pixels by default,
+ * but can be configured to trim any color using the `trimOptions` parameter.
+ *
+ * @param imageData `ImageData` of the image to trim
+ * @param trimOptions Options to configure the trim operation
+ * @returns a new, trimmed `ImageData` object
+ */
 export function trimImageData(imageData: ImageDataLike, trimOptions?: TrimOptions): ImageData {
   const trimEdges = getTrimEdges(imageData, trimOptions);
 


### PR DESCRIPTION
Closes #4 

## Context

It was requested in #4 to provide a way to just get the calculated edges without actually trimming the image data. Since it's a step being done internally, it's easy to break out and export as a separate function ✅ 

## Changes

- add and export `getTrimEdges()`
  - returns the calculated top, right, bottom and left edges to crop (which can be provided to `crop-image-data`)
- add typedocs to exported types and functions, since they were missing
- update readme